### PR TITLE
Update footer contact label and remove free text on landing page

### DIFF
--- a/frontend/src/app/routes/landing/components/landing-footer/landing-footer.component.html
+++ b/frontend/src/app/routes/landing/components/landing-footer/landing-footer.component.html
@@ -15,7 +15,9 @@
       <ul>
         @if (contactEmail) {
         <li>
-          <a href="mailto:{{ contactEmail }}">{{ contactEmail }}</a>
+          <a href="mailto:{{ contactEmail }}" i18n="@@landingFooterContactLinkLabel">
+            Feedback &amp; Support
+          </a>
         </li>
         }
         <li>

--- a/frontend/src/app/routes/landing/components/landing-main/landing-main.component.html
+++ b/frontend/src/app/routes/landing/components/landing-main/landing-main.component.html
@@ -38,14 +38,6 @@
     </span>
     <span class="bold" i18n="@@landingMainHeadingWithMelvin">with Melvin</span>
   </h1>
-  <ul>
-    <li class="chip landing-main-chip-dm" i18n="@@landingMainOpenSourceChip">
-      Open-Source
-    </li>
-    <li class="chip landing-main-chip-dm" i18n="@@landingMainFreeOfChargeChip">
-      Free of charge
-    </li>
-  </ul>
 </div>
 <!-- melvin intro -->
 <!-- https://melvin.shuffle-projekt.de/view/Twwm0uQUJAtr51OnkIwpCO85qk7NcwJefAHrngMmMTQfjLHJXn56UqDnxejjxd9D -->

--- a/frontend/src/locale/messages.de.xlf
+++ b/frontend/src/locale/messages.de.xlf
@@ -1254,14 +1254,6 @@
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Welcome to Melvin! </source>
         <target state="final"><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Willkommen zu Melvin! </target>
       </trans-unit>
-      <trans-unit id="landingMainOpenSourceChip" datatype="html">
-        <source> Open-Source </source>
-        <target state="final">Open-Source</target>
-      </trans-unit>
-      <trans-unit id="landingMainFreeOfChargeChip" datatype="html">
-        <source> Free of charge </source>
-        <target state="final">Kostenlos</target>
-      </trans-unit>
       <trans-unit id="landingMainRecordingHeading" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Recording </source>
         <target state="final"><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Aufnehmen </target>
@@ -2239,16 +2231,16 @@
         <target state="final"> Schlichtungsverfahren </target>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartOne" datatype="html">
-        <source> To ensure that this website meets the requirements described in Section 10 (1) L-BGG, you can contact the SHUFFLE project partners (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot; &gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>) by email and provide appropriate feedback. </source>
-        <target state="final"> Um zu gewährleisten, dass diese Webseite den in § 10 Absatz 1 L-BGG beschriebenen Anforderungen genügt, können Sie sich per Email an die SHUFFLE-Projekt-Partner (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot; &gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>) wenden und eine entsprechende Rückmeldung geben. </target>
+        <source> To ensure that this website meets the requirements described in Section 10 (1) L-BGG, you can contact the SHUFFLE project partners (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot;&gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>) by email and provide appropriate feedback. </source>
+        <target state="new"> Um zu gewährleisten, dass diese Webseite den in § 10 Absatz 1 L-BGG beschriebenen Anforderungen genügt, können Sie sich per Email an die SHUFFLE-Projekt-Partner (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot; &gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>) wenden und eine entsprechende Rückmeldung geben. </target>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartTwo" datatype="html">
         <source> If the Melvin project team does not respond to your request within four weeks, you may file a complaint with the National Center for Accessibility (LZ-BARR). </source>
         <target state="final"> Falls das Melvin-Projektteam nicht innerhalb von vier Wochen auf Ihre Anfrage antwortet, können Sie sich an die Schlichtungsstelle des Landeszentrums Barrierefreiheit (LZ-BARR) wenden. </target>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartThree" datatype="html">
-        <source> You can contact the National Center for Accessibility (LZ-BARR) as follows: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot; &gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Address: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </source>
-        <target state="final"> Die Schlichtungsstelle des Landeszentrums Barrierefreiheit (LZ-BARR) können Sie wie folgt erreichen: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot; &gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Adresse: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </target>
+        <source> You can contact the National Center for Accessibility (LZ-BARR) as follows: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot;&gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Address: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </source>
+        <target state="new"> Die Schlichtungsstelle des Landeszentrums Barrierefreiheit (LZ-BARR) können Sie wie folgt erreichen: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot; &gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Adresse: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </target>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartFour" datatype="html">
         <source> This procedure is free of charge. </source>
@@ -2373,6 +2365,10 @@
       <trans-unit id="landingFooterTutorialsHeader" datatype="html">
         <source>Tutorials</source>
         <target state="final">Anleitungen</target>
+      </trans-unit>
+      <trans-unit id="landingFooterContactLinkLabel" datatype="html">
+        <source> Feedback &amp; Support </source>
+        <target state="new"> Feedback &amp; Support </target>
       </trans-unit>
       <trans-unit id="landingFooterDidacticGuideLinkLabel" datatype="html">
         <source> Best Practice </source>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -1071,13 +1071,13 @@
         <source> Enforcement procedure </source>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartOne" datatype="html">
-        <source> To ensure that this website meets the requirements described in Section 10 (1) L-BGG, you can contact the SHUFFLE project partners (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot; &gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a &gt;"/>) by email and provide appropriate feedback. </source>
+        <source> To ensure that this website meets the requirements described in Section 10 (1) L-BGG, you can contact the SHUFFLE project partners (<x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:melvin@hdm-stuttgart.de&quot;&gt;"/>melvin@hdm-stuttgart.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>) by email and provide appropriate feedback. </source>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartTwo" datatype="html">
         <source> If the Melvin project team does not respond to your request within four weeks, you may file a complaint with the National Center for Accessibility (LZ-BARR). </source>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartThree" datatype="html">
-        <source> You can contact the National Center for Accessibility (LZ-BARR) as follows: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot; &gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Address: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </source>
+        <source> You can contact the National Center for Accessibility (LZ-BARR) as follows: <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:schlichtung@barrierefreiheit.bwl.de&quot;&gt;"/>schlichtung@barrierefreiheit.bwl.de<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> , <x id="START_LINK_1" equiv-text="&lt;a href=&quot;tel:004971112339375&quot;&gt;"/>Tel. +49 711 123 39375<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>, Address: Landeszentrum Barrierefreiheit, Schlichtungsstelle, Else-Josenhans-Straße 6, 70173 Stuttgart. </source>
       </trans-unit>
       <trans-unit id="accessibilityStatementEnforcementPartFour" datatype="html">
         <source> This procedure is free of charge. </source>
@@ -1475,6 +1475,9 @@
       <trans-unit id="landingFooterTutorialsHeader" datatype="html">
         <source>Tutorials</source>
       </trans-unit>
+      <trans-unit id="landingFooterContactLinkLabel" datatype="html">
+        <source> Feedback &amp; Support </source>
+      </trans-unit>
       <trans-unit id="landingFooterDidacticGuideLinkLabel" datatype="html">
         <source> Best Practice </source>
       </trans-unit>
@@ -1597,12 +1600,6 @@
       </trans-unit>
       <trans-unit id="landingMainIntroHeading" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Welcome to Melvin! </source>
-      </trans-unit>
-      <trans-unit id="landingMainOpenSourceChip" datatype="html">
-        <source> Open-Source </source>
-      </trans-unit>
-      <trans-unit id="landingMainFreeOfChargeChip" datatype="html">
-        <source> Free of charge </source>
       </trans-unit>
       <trans-unit id="landingMainRecordingHeading" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/><x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon svgIcon=&quot;video&quot; /&gt;"/> Recording </source>


### PR DESCRIPTION
Replace footer contact email with "Feedback & Support"
and remove free text on landing page.